### PR TITLE
add library paths for FreeBSD

### DIFF
--- a/libevent2-ssl.lisp
+++ b/libevent2-ssl.lisp
@@ -9,7 +9,8 @@
     (:darwin (:or "libevent_openssl.dylib"
                   ; brew's install of libevent on Mac OX X
                   "/usr/local/lib/libevent_openssl.dylib"))
-    (:unix (:or "libevent_openssl.so"
+    (:unix (:or "/usr/local/lib/event2/libevent_openssl.so"
+                "libevent_openssl.so"
                 "libevent_openssl-2.0.so.5"
                 "/usr/lib/libevent_openssl.so"
                 "/usr/local/lib/libevent_openssl.so"))

--- a/libevent2.lisp
+++ b/libevent2.lisp
@@ -14,7 +14,8 @@
               "libevent_core.dylib"
               ; brew's install of libevent on Mac OX X
               "/usr/local/lib/libevent_core.dylib"))
-    (:unix (:or "libevent_core.so"
+    (:unix (:or "/usr/local/lib/event2/libevent_core.so"
+                "libevent_core.so"
                 "libevent_core-2.0.so.5"
                 "/usr/lib/libevent_core.so"
                 "/usr/local/lib/libevent_core.so"))
@@ -28,7 +29,8 @@
     (:darwin (:or "libevent_extra.dylib"
                 ; brew's install of libevent on Mac OX X
               "/usr/local/lib/libevent_extra.dylib"))
-    (:unix (:or "libevent_extra.so"
+    (:unix (:or "/usr/local/lib/event2/libevent_extra.so"
+                "libevent_extra.so"
                 "libevent_extra-2.0.so.5"
                 "/usr/lib/libevent_extra.so"
                 "/usr/local/lib/libevent_extra.so"))


### PR DESCRIPTION
On FreeBSD "libevent_core.so" etc. will load libevent1 if installed and not search the directory in which libevent2 is installed. Putting the /usr/local/lib/event2/ line first seems to be necessary to keep CFFI from loading libevent1.
